### PR TITLE
UBL-339 Skip submission for remote publishing when publishing credent…

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ When needed, OASIS TC Administration posts the distribution package from Kavi to
 
 Every new result snapshots in the archive-only ZIP the Google spreadsheets at the time the results were created.
 
-If ever it is necessary to run the current publication process on an old snapshot from Google, this is accommodated by copying into the repository the three Google files from an archive-only ZIP:
+If ever it is necessary to run the current publication process on an old snapshot from Google, this is accommodated by copying into the parent directory of the repository the three Google files from an archive-only ZIP:
 - `UBL-Signature-Google.ods`
 - `UBL-Library-Google.ods`
 - `UBL-Documents-Google.ods`
@@ -388,7 +388,22 @@ A possible (but infrequent) scenario for this is when the production and packagi
 
 Another possible (but hopefully very infrequent) scenario for this is when it is necessary to recreate an old repository snapshot reproduction of the result after the online spreadsheets have changed. To re-run, check out the old branch to a new branch, add the ODS files from that branch's archive, and check in the new branch. The end results should be identical. 
 
-Remember to delete from the repository the Google ODS files in order to restart online access to the current Google spreadsheets.
+IMPORTANT: Remember to delete the Google ODS files from the parent directory in order to restart online access to the current Google spreadsheets.
+
+## Previewing results from one's local environment
+
+If you are in a shell environment (such as MacOS Terminal) you can create the results locally as a pre-test before pushing any commits to GitHub. The invocation is:
+```
+  ./build.sh {results-directory} {platform} {label} 
+```
+or if you have publishing credentials for the online publshing service:
+```
+  ./build.sh {results-directory} {platform} {label} {username} {password}
+```
+as in the following specifying "local" for the local machine and "debug" as a label to produce the results in a temporary directory:
+```
+  ./build.sh  ~/temp/ubl-results  local  debug 
+```
 
 ## Results
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$5" = "" ]; then echo Missing results directory, platform, label, realta-username, realta-password arguments ; exit 1 ; fi
+if [ "$3" = "" ]; then echo Missing results directory, platform, label \(, realta-username, realta-password arguments \) ; exit 1 ; fi
 
 export targetdir="$1"
 export platform=$2

--- a/build.xml
+++ b/build.xml
@@ -33,6 +33,11 @@
   <!--test skip-artefacts.txt for no artefacts at all-->
   <available property="skip-artefacts-generation" file="skip-artefacts.txt"/>
   <echo if:set="skip-artefacts-generation" message="!!!!!!!!!!!!!! Incomplete execution requested: artefacts are presumed to exist; delete skip-artefacts.txt to restore normal operation!!!!!!!!!!!!!!!!"/>
+  <!--without a publishing userid/password, full publishing not invoked-->
+  <condition property="skip-publish">
+    <equals arg1="${realtauser}" arg2=""/>
+  </condition>
+  <echo if:set="skip-publish" message="!!!!!!!!!!!!!! Incomplete execution requested: documentation not being generated in the absence of secret values!!!!!!!!!!!!!!!!"/>
   <!--override abieExtensions as "no" for UBL 2.2 and earlier-->
   <property name="abieExtensions" value="yes"/>
   <!--software timestamps-->
@@ -159,9 +164,12 @@ file="${utilitydir}Crane-cva2sch-${cva2sch}/utility/iso_schematron_assembly.xsl"
     <delete file="${dir}/UBL-Entities-${UBLversion}.gc"/>
     
     <available property="google-sig-file-exists"
-               file="${dir}/UBL-Signature-Google.ods"/>
+               file="../UBL-Signature-Google.ods"/>
     <echo if:set="google-sig-file-exists"
  message="Using local copy of signature Google spreadsheet; no online access"/>
+    <copy if:set="google-sig-file-exists"
+          file="../UBL-Signature-Google.ods"
+          tofile="${dir}/UBL-Signature-Google.ods"/>
     <sequential unless:set="google-sig-file-exists">
       <echo file="${dir}/wget-signature-time.txt" message="${localTime}"/>
       <echo file="${dir}/wget-signature-uri.txt" message="${signatureGoogle}"/>
@@ -212,9 +220,12 @@ file="${utilitydir}Crane-cva2sch-${cva2sch}/utility/iso_schematron_assembly.xsl"
            file="${dir}/VALID-SIGNATURE-GC-FILE-NOT-GENERATED.txt"/>
   
     <available property="google-library-file-exists"
-               file="${dir}/UBL-Library-Google.ods"/>
+               file="../UBL-Library-Google.ods"/>
     <echo if:set="google-library-file-exists"
-   message="Using local copy of library Google spreadsheet; no online access"/>
+ message="Using local copy of library Google spreadsheet; no online access"/>
+    <copy if:set="google-library-file-exists"
+          file="../UBL-Library-Google.ods"
+          tofile="${dir}/UBL-Library-Google.ods"/>
     <sequential unless:set="google-library-file-exists">
       <echo file="${dir}/wget-model-time.txt" message="${localTime}"/>
       <echo file="${dir}/wget-model-library-uri.txt"
@@ -227,9 +238,12 @@ file="${utilitydir}Crane-cva2sch-${cva2sch}/utility/iso_schematron_assembly.xsl"
     </sequential>
     
     <available property="google-documents-file-exists"
-               file="${dir}/UBL-Documents-Google.ods"/>
+               file="../UBL-Documents-Google.ods"/>
     <echo if:set="google-documents-file-exists"
  message="Using local copy of documents Google spreadsheet; no online access"/>
+    <copy if:set="google-documents-file-exists"
+          file="../UBL-Documents-Google.ods"
+          tofile="${dir}/UBL-Documents-Google.ods"/>
     <sequential unless:set="google-library-file-exists">
       <echo file="${dir}/wget-model-time.txt" message="${localTime}"/>
       <echo file="${dir}/wget-model-documents-uri.txt"
@@ -1134,9 +1148,7 @@ file="${utilitydir}Crane-cva2sch-${cva2sch}/utility/iso_schematron_assembly.xsl"
   <!--<echo message="datetimelocal=${datetimelocal}"/>-->
   <echo message="includeISO=${includeISO}"/>
 
-  <!--test skip-publish.txt to preserve the old genericode model file-->
-  <available property="skip-publish" file="skip-publish.txt"/>
-  <echo if:set="skip-publish" message="!!!!!!!!!!!!!! Incomplete execution requested: UBL-Entities-${UBLversion}.gc not being generated from the given spreadsheets; delete skip-publish.txt to restore normal operation!!!!!!!!!!!!!!!!"/>
+  <echo if:set="skip-publish" message="!!!!!!!!!!!!!! Incomplete execution requested: documentation not being generated in the absence of secret values!!!!!!!!!!!!!!!!"/>
 
   <!--preserve old entities for archive and copmarison-->
   <delete dir="${dir}/old-entities"/>


### PR DESCRIPTION
…ials are absent

I've tested this by forking this repository to an account without publishing credentials and the production process went smoothly by gracefully skipping the remote publishing component since there were no credentials in the secret values.

I think it is ready to go.

. . . . Ken