### PR TITLE
UBL-338 Repair generation of document constratin Schematron syntax

### DIFF
--- a/gc2sch.xsl
+++ b/gc2sch.xsl
@@ -149,9 +149,11 @@ The following is a summary of the additional document constraints:
       <pattern>
          <rule context="ext:*">
            <xsl:comment select="'no constraints for extension elements'"/>
+           <report test="false()"/>
          </rule>
          <rule context="ext:*//*">
            <xsl:comment select="'no constraints in extension elements'"/>
+           <report test="false()"/>
          </rule>
         <rule context="*[not(*)]">
           <assert test="normalize-space(.)"


### PR DESCRIPTION
The generated Schematron schema was schema-invalid but never interrupted the validation process. This change makes the generated schema to be schema-valid.